### PR TITLE
Support font path override

### DIFF
--- a/open-sans-condensed.scss
+++ b/open-sans-condensed.scss
@@ -1,4 +1,4 @@
-$FontPathOpenSansCondensed: "./fonts";
+$FontPathOpenSansCondensed: "./fonts" !default;
 
 @font-face {
   font-family: 'Open Sans Condensed';


### PR DESCRIPTION
If someone wants to copy fonts to another directory, they can override `$FontPathOpenSansCondensed` SaSS variable.